### PR TITLE
add a variable in noiseDB for coh noise filter

### DIFF
--- a/inc/WireCellSigProc/Microboone.h
+++ b/inc/WireCellSigProc/Microboone.h
@@ -30,7 +30,7 @@ namespace WireCell {
 	    bool NoisyFilterAlg(WireCell::Waveform::realseq_t& spec, float min_rms, float max_rms);
 
 	    std::vector< std::vector<int> > SignalProtection(WireCell::Waveform::realseq_t& sig, const WireCell::Waveform::compseq_t& respec, int res_offset, int pad_f, int pad_b, float upper_decon_limit = 0.02, float decon_lf_cutoff = 0.08, float upper_adc_limit = 15, float protection_factor = 5.0, float min_adc_limit = 50);
-	    bool Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& chansig, const WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, std::vector< std::vector<int> >& rois, float upper_decon_limit1=0.08);
+	    bool Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& chansig, const WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, std::vector< std::vector<int> >& rois, float upper_decon_limit1=0.08, float roi_min_max_ratio=0.8);
 
 
             // hold common config stuff

--- a/inc/WireCellSigProc/OmniChannelNoiseDB.h
+++ b/inc/WireCellSigProc/OmniChannelNoiseDB.h
@@ -53,6 +53,7 @@ namespace WireCell {
 	    virtual float coherent_nf_adc_limit(int channel) const;
 	    virtual float coherent_nf_protection_factor(int channel) const;
 	    virtual float coherent_nf_min_adc_limit(int channel) const;
+	    virtual float coherent_nf_roi_min_max_ratio(int channel) const;
 	    
 	    virtual const filter_t& rcrc(int channel) const;
 	    virtual const filter_t& config(int channel) const;
@@ -120,6 +121,7 @@ namespace WireCell {
 		float decon_limit1;
 		float protection_factor;
 		float min_adc_limit;
+		float roi_min_max_ratio;
 		
                 // parameters
     

--- a/inc/WireCellSigProc/SimpleChannelNoiseDB.h
+++ b/inc/WireCellSigProc/SimpleChannelNoiseDB.h
@@ -38,6 +38,7 @@ namespace WireCell {
 	    virtual float coherent_nf_adc_limit(int channel) const;
 	    virtual float coherent_nf_protection_factor(int channel) const;
 	    virtual float coherent_nf_min_adc_limit(int channel) const;
+	    virtual float coherent_nf_roi_min_max_ratio(int channel) const;
 	    
 	    virtual double min_rms_cut(int channel) const;
 	    virtual double max_rms_cut(int channel) const;
@@ -88,6 +89,7 @@ namespace WireCell {
 	    void set_coherent_nf_adc_limit(const std::vector<int>& channels, float adc_limit);
 	    void set_coherent_nf_protection_factor(const std::vector<int>& channels, float protection_factor);
 	    void set_coherent_nf_min_adc_limit(const std::vector<int>& channels, float min_adc_limit);
+	    void set_coherent_nf_roi_min_max_ratio(const std::vector<int>& channels, float roi_min_max_ratio);
 	    
 	    void set_min_rms_cut(const std::vector<int>& channels, double min_rms);
 	    void set_min_rms_cut_one(int channel, double min_rms);
@@ -132,11 +134,11 @@ namespace WireCell {
 	    double m_default_baseline, m_default_gain, m_default_offset;
 	    double m_default_min_rms, m_default_max_rms;
 	    int m_default_pad_f, m_default_pad_b;
-	    float m_default_decon_limit, m_default_decon_lf_cutoff, m_default_adc_limit, m_default_decon_limit1, m_default_protection_factor, m_default_min_adc_limit;
+	    float m_default_decon_limit, m_default_decon_lf_cutoff, m_default_adc_limit, m_default_decon_limit1, m_default_protection_factor, m_default_min_adc_limit, m_default_roi_min_max_ratio;
 
 	    std::vector<double> m_baseline, m_gain, m_offset, m_min_rms, m_max_rms;
 	    std::vector<int> m_pad_f, m_pad_b;
-	    std::vector<float> m_decon_limit, m_decon_lf_cutoff, m_adc_limit, m_decon_limit1, m_protection_factor, m_min_adc_limit;
+	    std::vector<float> m_decon_limit, m_decon_lf_cutoff, m_adc_limit, m_decon_limit1, m_protection_factor, m_min_adc_limit, m_roi_min_max_ratio;
 
 
 	    typedef std::shared_ptr<filter_t> shared_filter_t;

--- a/src/Microboone.cxx
+++ b/src/Microboone.cxx
@@ -57,7 +57,8 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 				   const WireCell::Waveform::compseq_t& respec,
 				   int res_offset,
 				   std::vector< std::vector<int> >& rois,
-				   float decon_limit1)
+				   float decon_limit1,
+                   float roi_min_max_ratio)
 {
     double ave_coef = 0;
     double_t ave_coef1 = 0;
@@ -94,7 +95,7 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 	// if (coef > 1.5) coef = 1.5;
 
 	coef_all[ch] = coef;
-	if (coef != 0){
+	if (coef != 0){ // FIXME: expect some fluctuation?
 	    ave_coef += coef;
 	    ave_coef1 ++;
 	}
@@ -180,7 +181,7 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 		//		if (signal.ch==1027)
 		//std::cout << roi.front() << " Xin " << max_val << " " << decon_limit1 << std::endl;
 		
-		if ( max_val > decon_limit1 && fabs(min_val) < max_val * 0.8)
+		if ( max_val > decon_limit1 && fabs(min_val) < max_val * roi_min_max_ratio)
 		    flag_replace[roi.front()] = true;
 	    }
 	    
@@ -897,6 +898,7 @@ Microboone::CoherentNoiseSub::apply(channel_signals_t& chansig) const
     const float decon_lf_cutoff = m_noisedb->coherent_nf_decon_lf_cutoff(achannel);
     const float adc_limit = m_noisedb->coherent_nf_adc_limit(achannel);//15;
     const float decon_limit1 = m_noisedb->coherent_nf_decon_limit1(achannel);// 0.08; // loose filter
+    const float roi_min_max_ratio = m_noisedb->coherent_nf_roi_min_max_ratio(achannel);// 0.8 default
 
     const float protection_factor = m_noisedb->coherent_nf_protection_factor(achannel);
     const float min_adc_limit = m_noisedb->coherent_nf_min_adc_limit(achannel);
@@ -924,7 +926,7 @@ Microboone::CoherentNoiseSub::apply(channel_signals_t& chansig) const
     //std::cerr <<"\tSigprotection done: " << chansig.size() << " " << medians.size() << " " << medians.at(100) << " " << medians.at(101) << std::endl;
 
     // calculate the scaling coefficient and subtract
-    Microboone::Subtract_WScaling(chansig, medians, respec, res_offset, rois, decon_limit1);
+    Microboone::Subtract_WScaling(chansig, medians, respec, res_offset, rois, decon_limit1, roi_min_max_ratio);
 
     
     // WireCell::IChannelFilter::signal_t& signal = chansig.begin()->second;

--- a/src/OmniChannelNoiseDB.cxx
+++ b/src/OmniChannelNoiseDB.cxx
@@ -42,6 +42,7 @@ OmniChannelNoiseDB::ChannelInfo::ChannelInfo()
     , decon_limit1(0.08)
     , protection_factor(5.0)
     , min_adc_limit(50)
+    , roi_min_max_ratio(0.8)
     , rcrc(nullptr)
     , config(nullptr)
     , noise(nullptr)
@@ -518,6 +519,13 @@ void OmniChannelNoiseDB::update_channels(Json::Value cfg)
             get_ci(ch).min_adc_limit = val;
         }
     }
+    if (cfg.isMember("roi_min_max_ratio")) {
+        float val = cfg["roi_min_max_ratio"].asDouble();
+        dump_cfg("roiminmaxratio", chans, val);
+        for (int ch : chans) {
+            get_ci(ch).min_adc_limit = val;
+        }
+    }
     
     {
         auto jfilt = cfg["rcrc"];
@@ -705,6 +713,10 @@ float OmniChannelNoiseDB::coherent_nf_min_adc_limit(int channel) const
     return dbget(channel).min_adc_limit;
 }
 
+float OmniChannelNoiseDB::coherent_nf_roi_min_max_ratio(int channel) const
+{
+    return dbget(channel).roi_min_max_ratio;
+}
 
 const IChannelNoiseDatabase::filter_t& OmniChannelNoiseDB::rcrc(int channel) const
 {

--- a/src/SimpleChannelNoiseDB.cxx
+++ b/src/SimpleChannelNoiseDB.cxx
@@ -28,6 +28,7 @@ SimpleChannelNoiseDB::SimpleChannelNoiseDB(double tick, int nsamples)
     , m_default_decon_limit1(0.08)
     , m_default_protection_factor(5.0)
     , m_default_min_adc_limit(50)
+    , m_default_roi_min_max_ratio(0.8)
 {
     set_sampling(tick, nsamples);
 }
@@ -154,11 +155,20 @@ float SimpleChannelNoiseDB::coherent_nf_min_adc_limit(int channel) const
 {
     const int ind = chind(channel);
     if (0 <= ind && ind < (int)m_min_adc_limit.size()) {
-	return m_min_adc_limit[ind];
+    return m_min_adc_limit[ind];
     }
     return m_default_min_adc_limit;
 }
 
+
+float SimpleChannelNoiseDB::coherent_nf_roi_min_max_ratio(int channel) const
+{
+    const int ind = chind(channel);
+    if (0 <= ind && ind < (int)m_roi_min_max_ratio.size()) {
+    return m_roi_min_max_ratio[ind];
+    }
+    return m_default_roi_min_max_ratio;
+}
 
 
 const IChannelNoiseDatabase::filter_t& SimpleChannelNoiseDB::get_filter(int channel, const filter_vector_t& fv) const
@@ -447,6 +457,14 @@ void SimpleChannelNoiseDB::set_coherent_nf_min_adc_limit(const std::vector<int>&
     }
 }
 
+void SimpleChannelNoiseDB::set_coherent_nf_roi_min_max_ratio(const std::vector<int>& channels, float roi_min_max_ratio)
+{
+    //std::cerr << "SimpleChannelNoiseDB: set pad window back on " << channels.size() << " channels: " << pad_b << std::endl;
+    for (auto ch : channels) {
+    int ind = chind(ch);
+    set_one(ind, roi_min_max_ratio, m_roi_min_max_ratio, m_default_roi_min_max_ratio);
+    }
+}
 
 void SimpleChannelNoiseDB::set_filter(const std::vector<int>& channels, const multimask_t& masks)
 {


### PR DESCRIPTION
The coherent noise filter needs to be adjusted for the case of protoDUNE. [Here](https://github.com/WireCell/wire-cell-sigproc/files/3488432/Gaps_CohFilter.pdf) are some details about the coherent noise removal. Therefore, it's better to change a hard-coded variable into a configurable one via a method `coherent_nf_roi_min_max_ratio()` in  **OmniChannelNoiseDB**. To be consistent with the current framework, similar methods will be implemented in iface::IChannelNoiseDB, SimpleChannelNoiseDB,  as well as larwirecell::MultiChannelNoiseDB.
