### PR TITLE
Fix a bug in the variable configuration

### DIFF
--- a/src/OmniChannelNoiseDB.cxx
+++ b/src/OmniChannelNoiseDB.cxx
@@ -523,7 +523,7 @@ void OmniChannelNoiseDB::update_channels(Json::Value cfg)
         float val = cfg["roi_min_max_ratio"].asDouble();
         dump_cfg("roiminmaxratio", chans, val);
         for (int ch : chans) {
-            get_ci(ch).min_adc_limit = val;
+            get_ci(ch).roi_min_max_ratio = val;
         }
     }
     


### PR DESCRIPTION
Hi Brett,

I notice that I had a stupid typo in the sigproc/OmniChannelNoiseDB. Since the default initial value for `roi_min_max_ratio` is 0.8, uboone should not be affected. The only case that this bug makes a mistake is when someone explicitly configures this value in the chandb-xx.jsonnet.  

So it might be fine if we leave this and correct it in the next week's release. What you think?

TIL: I could have more thorough tests before the pull requst. Below I pasted a plot of frequency spectrum that I explicitly configure  `roi_min_max_ratio` in the jsonnet, indicating that this bug is gone.
![image](https://user-images.githubusercontent.com/10663117/62952545-d912d400-bdb9-11e9-87c2-065b8d7a161e.png)
