### PR TITLE
add an optional debug mode to seperate ROI refinement step by step

### DIFF
--- a/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/inc/WireCellSigProc/OmnibusSigProc.h
@@ -8,8 +8,12 @@
 #include "WireCellUtil/Array.h"
 #include "WireCellUtil/Logging.h"
 
+#include <list>
+
 namespace WireCell {
   namespace SigProc {
+
+    class SignalROI; //forward declaration
     class OmnibusSigProc : public WireCell::IFrameFilter, public WireCell::IConfigurable {
     public:
       OmnibusSigProc(const std::string& anode_tn = "AnodePlane",
@@ -47,7 +51,15 @@ namespace WireCell {
                      int charge_ch_offset = 10000,
                      const std::string& wiener_tag = "wiener",
                      const std::string& wiener_threshold_tag = "threshold",
-                     const std::string& gauss_tag = "gauss" );
+                     const std::string& gauss_tag = "gauss",
+                     bool use_roi_debug_mode = false,
+                     const std::string& tight_lf_tag = "tight_lf",
+                     const std::string& loose_lf_tag = "loose_lf",
+                     const std::string& cleanup_roi_tag = "cleanup_roi",
+                     const std::string& break_roi_loop1_tag = "break_roi_1st",
+                     const std::string& break_roi_loop2_tag = "break_roi_2nd",
+                     const std::string& shrink_roi_tag = "shrink_roi",
+                     const std::string& extend_roi_tag = "extend_roi" );
       virtual ~OmnibusSigProc();
       
       virtual bool operator()(const input_pointer& in, output_pointer& out);
@@ -73,6 +85,10 @@ namespace WireCell {
       void save_data(ITrace::vector& itraces, IFrame::trace_list_t& indices, int plane,
                      const std::vector<float>& perwire_rmses,
                      IFrame::trace_summary_t& threshold);
+
+      // save ROI into the out frame (set use_roi_debug_mode=true)
+      void save_roi(ITrace::vector& itraces, IFrame::trace_list_t& indices, int plane,
+                    std::vector<std::list<SignalROI*> >& roi_channel_list);
 
       // initialize the overall response function ...
       void init_overall_response(IFrame::pointer frame);
@@ -190,6 +206,15 @@ namespace WireCell {
       std::string m_wiener_threshold_tag;
       std::string m_gauss_tag;
       std::string m_frame_tag;
+
+      bool m_use_roi_debug_mode;
+      std::string m_tight_lf_tag;
+      std::string m_loose_lf_tag;
+      std::string m_cleanup_roi_tag;
+      std::string m_break_roi_loop1_tag;
+      std::string m_break_roi_loop2_tag;
+      std::string m_shrink_roi_tag;
+      std::string m_extend_roi_tag;
 
       // If true, safe output as a sparse frame.  Traces will only
       // cover segments of waveforms which have non-zero signal

--- a/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/inc/WireCellSigProc/OmnibusSigProc.h
@@ -80,6 +80,8 @@ namespace WireCell {
       void decon_2D_looseROI(int plane);
       void decon_2D_hits(int plane);
       void decon_2D_charge(int plane);
+
+      void decon_2D_looseROI_debug_mode(int plane);
       
       // save data into the out frame and collect the indices
       void save_data(ITrace::vector& itraces, IFrame::trace_list_t& indices, int plane,

--- a/src/ROI_refinement.cxx
+++ b/src/ROI_refinement.cxx
@@ -198,6 +198,13 @@ void ROI_refinement::apply_roi(int plane, Array::array_xxf& r_data){
   }
 }
 
+// helper function for getting ROIs
+SignalROIChList& ROI_refinement::get_rois_by_plane(int plane)
+{
+  if (plane==0) return get_u_rois();
+  else if (plane==1) return get_v_rois();
+  else return get_w_rois();
+}
 
 void ROI_refinement::unlink(SignalROI* prev_roi, SignalROI* next_roi){
   if (front_rois.find(prev_roi)!=front_rois.end()){
@@ -2191,6 +2198,48 @@ void ROI_refinement::refine_data(int plane, ROI_formation& roi_form){
   //TestROIs();
   //if (plane==2)  std::cout << "Xin: " << rois_w_tight.at(69).size() << " " << std::endl;
 }
+
+// Basically rewrite the refine_data()
+// But now do the ROI operation step by step
+void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, const std::string& cmd){
+
+  if (cmd=="CleanUpROIs") {
+    // std::cout << "Clean up loose ROIs" << std::endl;
+    CleanUpROIs(plane);
+    //std::cout << "Generate more loose ROIs from isolated good tight ROIs" << std::endl;
+    generate_merge_ROIs(plane);
+  }
+
+  else if (cmd=="BreakROIs") {
+    // std::cout << "Break loose ROIs" << std::endl;
+    BreakROIs(plane, roi_form);
+    // std::cout << "Clean up ROIs 2nd time" << std::endl;
+    CheckROIs(plane, roi_form);
+    CleanUpROIs(plane);
+  }
+
+  else if (cmd=="ShrinkROIs") {
+    //  std::cout << "Shrink ROIs" << std::endl;
+    ShrinkROIs(plane, roi_form);
+    // std::cout << "Clean up ROIs 3rd time" << std::endl;
+    CheckROIs(plane, roi_form);
+    CleanUpROIs(plane);
+  }
+
+  else if (cmd=="ExtendROIs") {
+    // Further reduce fake hits
+    // std::cout << "Remove fake hits " << std::endl;
+    if (plane==2){
+      CleanUpCollectionROIs();
+    }else{
+      CleanUpInductionROIs(plane);
+    }
+
+    ExtendROIs();
+    //TestROIs();
+  }
+
+ }
 
 void ROI_refinement::TestROIs(){
   

--- a/src/ROI_refinement.h
+++ b/src/ROI_refinement.h
@@ -25,12 +25,14 @@ namespace WireCell{
       // initialize the ROIs
       void load_data(int plane, const Array::array_xxf& r_data, ROI_formation& roi_form);
       void refine_data(int plane, ROI_formation& roi_form);
+      void refine_data_debug_mode(int plane, ROI_formation& roi_form, const std::string& cmd);
 
       void apply_roi(int plane, Array::array_xxf& r_data);
       
       SignalROIChList& get_u_rois(){return rois_u_loose;};
       SignalROIChList& get_v_rois(){return rois_v_loose;};
       SignalROIChList& get_w_rois(){return rois_w_tight;};
+      SignalROIChList& get_rois_by_plane(int plane);
       
     private:
       int nwire_u;


### PR DESCRIPTION
ROI_refinement::refine_data_debug_mode() is copied from refine_data() except that it is splitted into several parts. In between each part, user can save the current data (m_r_data) with OmnibusSigproc::save_data() and save_roi().

A configurable parameter `use_roi_debug_mode=false` is added. There is almost no actual **write** operation on data if the users turn on the debug mode. A new filter function  OmnibusSigproc::decon_2D_looseROI_debug_mode() is added to have a loose LF only filter. Because the current decon_2D_looseROI() contains both loose and tight LF in the same function, I have to create this new one.

Given that the decon_2D_looseROI_debug_mode() only write to m_r_data, the actual data in **m_c_data** (the frequency-domain data) does not change. And the m_r_data will be recovered in the next call of decon_2D_looseROI().

I attached some figures that display the ROI information from this debug mode and dumped with **MagnifySink**.
![image](https://user-images.githubusercontent.com/10663117/63549989-a2e2fc00-c4ff-11e9-9020-e49245b0008b.png)

![image](https://user-images.githubusercontent.com/10663117/63550000-aa0a0a00-c4ff-11e9-9da9-cdb1beb41d9f.png)

